### PR TITLE
Windows 11 Sneedful Edition Key

### DIFF
--- a/winactivate.cmd
+++ b/winactivate.cmd
@@ -249,6 +249,10 @@ for /f %%a in ('powershell -command "(Get-WmiObject Win32_OperatingSystem).Opera
         set "product_key=QPM6N-7J2WJ-P88HH-P3YRH-YY74H"
         set "product_key_is_retail=1"
     )
+    if "%%a" equ "203" (
+        set "product_key=KY7PN-VR6RX-83W6Y-6DDYQ-T6R4W"
+        set "product_key_is_retail=1"
+    )
 )
 
 


### PR DESCRIPTION
Sir ,
This PC isn’t set up securely—data may be at risk.
Contact your retailer or manufacturer for service and repair.
Windows 11 SE
Build 22000.co_release.210604-1628
do the needful ,
uwuowouwu420